### PR TITLE
Fix al solapamiento del último item en pantallas de poca altura.

### DIFF
--- a/src/layout/base.astro
+++ b/src/layout/base.astro
@@ -26,6 +26,7 @@ const { title } = Astro.props;
     --offset: 0.5rem;
 
     --default-font: "Open Sans", sans-serif, system-ui;
+    --player-height: 125px;
   }
 
   html {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,12 +13,10 @@ const title = "Music Manz Player - Manz.dev";
 
 <style>
   .container {
-    --player-height: 125px;
-
     display: grid;
     grid-template-columns: 1fr;
     grid-template-rows: 30px 1fr;
-    height: 100%;
+    /* height: 100%; */
     justify-content: center;
     background: var(--dark-bgcolor);
     padding: 1rem;

--- a/src/ui/Content/index.astro
+++ b/src/ui/Content/index.astro
@@ -11,11 +11,14 @@ import ListHeader from "./ListHeader.astro";
     display: grid;
     background: linear-gradient(to bottom, var(--theme-color), var(--dark-theme-color) 60%);
     border-radius: var(--border-radius);
-    max-height: 82vh;
+    max-height: calc(100vh - (var(--player-height) + 50px));
     overflow-y: scroll;
 
     @media (width <= 1300px) {
       height: calc(100% - 250px - 20px);
+    }
+    @media (width <= 767px) {
+      height: calc(100% - 250px);
     }
 
     &::before {

--- a/src/ui/Sidebar/MainSidebar.astro
+++ b/src/ui/Sidebar/MainSidebar.astro
@@ -85,11 +85,16 @@ const sortRule = (a, b) => a.pinned ? -1 : 1;
       gap: 0 0.5rem;
       padding: 0 0.5rem;
       max-width: 90vw;
-
+      overflow-y: scroll;
+      max-height: calc(100vh - 350px);
+      @media (height <= 700px) and (width >= 1300px) {
+        max-height: calc(100vh - 300px);
+      }
       @media (width <= 1300px) {
         display: grid;
         grid-auto-flow: column dense;
         overflow-x: scroll;
+        overflow-y: auto;
       }
     }
 


### PR DESCRIPTION
Cambios del css para que al hacer scroll en la lista de canciones siempre se puede llegar a ver el último item sin que el reproductor lo solape.